### PR TITLE
Refactor common functions

### DIFF
--- a/handlers/http/outbound.go
+++ b/handlers/http/outbound.go
@@ -7,11 +7,12 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/StanzaSystems/sdk-go/hub"
 	"github.com/StanzaSystems/sdk-go/keys"
+	"github.com/StanzaSystems/sdk-go/otel"
 	hubv1 "github.com/StanzaSystems/sdk-go/proto/stanza/hub/v1"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
@@ -95,8 +96,8 @@ func (h *OutboundHandler) Post(ctx context.Context, url string, body io.Reader, 
 
 func (h *OutboundHandler) Request(ctx context.Context, httpMethod, url string, body io.Reader, tlr *hubv1.GetTokenLeaseRequest) (*http.Response, error) {
 	// Inspect Baggage and Headers for Feature and PriorityBoost, propagate through context if found
-	ctx, tlr.Selector.FeatureName = getFeature(ctx, tlr.Selector.GetFeatureName())
-	ctx, tlr.PriorityBoost = getPriorityBoost(ctx, tlr.GetPriorityBoost())
+	ctx, tlr.Selector.FeatureName = otel.GetFeature(ctx, tlr.Selector.GetFeatureName())
+	ctx, tlr.PriorityBoost = otel.GetPriorityBoost(ctx, tlr.GetPriorityBoost())
 
 	// Add Decorator and Feature to OTEL attributes
 	attr := append(h.attr,
@@ -130,7 +131,7 @@ func (h *OutboundHandler) Request(ctx context.Context, httpMethod, url string, b
 }
 
 func (h *OutboundHandler) request(ctx context.Context, req *http.Request, tlr *hubv1.GetTokenLeaseRequest, attr []attribute.KeyValue) (*http.Response, error) {
-	if ok, token := checkQuota(h.apikey, h.decoratorConfig[tlr.Selector.DecoratorName], h.qsc, tlr); ok {
+	if ok, token := hub.CheckQuota(h.apikey, h.decoratorConfig[tlr.Selector.DecoratorName], h.qsc, tlr); ok {
 		if token != "" {
 			req.Header.Add("X-Stanza-Token", token)
 		}

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -1,4 +1,4 @@
-package http
+package hub
 
 import (
 	"context"
@@ -36,7 +36,7 @@ var (
 	consumedLeasesInit sync.Once
 )
 
-func checkQuota(apikey string, dc *hubv1.DecoratorConfig, qsc hubv1.QuotaServiceClient, tlr *hubv1.GetTokenLeaseRequest) (bool, string) {
+func CheckQuota(apikey string, dc *hubv1.DecoratorConfig, qsc hubv1.QuotaServiceClient, tlr *hubv1.GetTokenLeaseRequest) (bool, string) {
 	// Start a background batch token consumer (the first time checkQuota is called)
 	consumedLeasesInit.Do(func() { go batchTokenConsumer(apikey, qsc) })
 
@@ -249,7 +249,7 @@ func cachedLeaseManager(apikey string, qsc hubv1.QuotaServiceClient) {
 	}
 }
 
-func validateTokens(apikey, environment, decorator string, dc *hubv1.DecoratorConfig, qsc hubv1.QuotaServiceClient, tokens []string) bool {
+func ValidateTokens(apikey, environment, decorator string, dc *hubv1.DecoratorConfig, qsc hubv1.QuotaServiceClient, tokens []string) bool {
 	if !dc.GetValidateIngressTokens() {
 		return true // if we weren't asked to validate ingress tokens, don't
 	}

--- a/otel/baggage.go
+++ b/otel/baggage.go
@@ -1,4 +1,4 @@
-package http
+package otel
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/otel/baggage"
 )
 
-func getFeature(ctx context.Context, feat string) (context.Context, *string) {
+func GetFeature(ctx context.Context, feat string) (context.Context, *string) {
 	if feat == "" { // If Feature is already supplied, use it
 		featFromBaggage := baggage.FromContext(ctx).Member(keys.StzFeat).Value()
 		if featFromBaggage != "" { // Otherwise inspect OTEL baggage
@@ -38,7 +38,7 @@ func getFeature(ctx context.Context, feat string) (context.Context, *string) {
 	return ctx, &feat
 }
 
-func getPriorityBoost(ctx context.Context, boost int32) (context.Context, *int32) {
+func GetPriorityBoost(ctx context.Context, boost int32) (context.Context, *int32) {
 	// Handle additional PriorityBoost (from OTEL baggage or known headers)
 	boostFromBaggage := baggage.FromContext(ctx).Member(keys.StzBoost).Value()
 	if boostFromBaggage != "" {

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -7,10 +7,13 @@ import (
 	"github.com/StanzaSystems/sdk-go/logging"
 	hubv1 "github.com/StanzaSystems/sdk-go/proto/stanza/hub/v1"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	ot "go.opentelemetry.io/otel/trace"
 )
 
 var (
@@ -64,4 +67,14 @@ func InitTraceProvider(ctx context.Context, tc *hubv1.TraceConfig, token string)
 		}
 	}
 	return nil
+}
+
+// GetTextMapPropagator is a passthrough helper function
+func GetTextMapPropagator() propagation.TextMapPropagator {
+	return otel.GetTextMapPropagator()
+}
+
+// GetTracePropagator is a passthrough helper function
+func GetTracerProvider() ot.TracerProvider {
+	return otel.GetTracerProvider()
 }


### PR DESCRIPTION
- Stanza Hub -> `hub`
- OTEL baggage -> `otel`

Allows for purely common functions to be called from new handlers.