### PR TITLE
Refactor SDK init sequence

### DIFF
--- a/adapters/fiberstanza/example/server.go
+++ b/adapters/fiberstanza/example/server.go
@@ -71,6 +71,9 @@ func main() {
 			Name:        name,
 			Release:     release,
 			Environment: env,
+
+			// optionally prefetch Decorator configs
+			Decorators: []string{"StressTest"},
 		})
 	defer stanzaExit()
 	if stanzaInitErr != nil {
@@ -172,7 +175,6 @@ func main() {
 		}
 		return c.SendStatus(resp.StatusCode)
 	})
-	logger.Info("Stanza example server listening ", zap.Int("port", port))
 	go app.Listen(fmt.Sprintf(":%d", port))
 
 	// GRACEFUL SHUTDOWN

--- a/adapters/fiberstanza/fiberstanza.go
+++ b/adapters/fiberstanza/fiberstanza.go
@@ -30,6 +30,8 @@ type Client struct {
 	Release     string // defines applications version
 	Environment string // defines applications environment
 	StanzaHub   string // host:port (ipv4, ipv6, or resolvable hostname)
+
+	Decorators []string // prefetch config for these decorators
 }
 
 // Optional arguments

--- a/stanza/client.go
+++ b/stanza/client.go
@@ -72,8 +72,8 @@ func GetNewBearerToken(ctx context.Context) bool {
 	return false
 }
 
-func GetServiceConfig(ctx context.Context) {
-	if time.Now().After(gs.svcConfigTime.Add(jitter(SERVICE_CONFIG_REFRESH_INTERVAL, SERVICE_CONFIG_REFRESH_JITTER))) {
+func GetServiceConfig(ctx context.Context, skipPoll bool) {
+	if skipPoll || time.Now().After(gs.svcConfigTime.Add(jitter(SERVICE_CONFIG_REFRESH_INTERVAL, SERVICE_CONFIG_REFRESH_JITTER))) {
 		md := metadata.New(map[string]string{"x-stanza-key": gs.clientOpt.APIKey})
 		res, err := gs.hubConfigClient.GetServiceConfig(
 			metadata.NewOutgoingContext(ctx, md),
@@ -154,10 +154,10 @@ func GetServiceConfig(ctx context.Context) {
 	}
 }
 
-func GetDecoratorConfigs(ctx context.Context) {
+func GetDecoratorConfigs(ctx context.Context, skipPoll bool) {
 	if len(gs.decoratorConfig) > 0 {
 		for decorator := range gs.decoratorConfig {
-			if time.Now().After(gs.decoratorConfigTime[decorator].Add(jitter(DECORATOR_CONFIG_REFRESH_INTERVAL, DECORATOR_CONFIG_REFRESH_JITTER))) {
+			if skipPoll || time.Now().After(gs.decoratorConfigTime[decorator].Add(jitter(DECORATOR_CONFIG_REFRESH_INTERVAL, DECORATOR_CONFIG_REFRESH_JITTER))) {
 				GetDecoratorConfig(ctx, decorator)
 			}
 		}

--- a/stanza/stanza.go
+++ b/stanza/stanza.go
@@ -18,6 +18,8 @@ type ClientOptions struct {
 	Release     string // defines applications version
 	Environment string // defines applications environment
 	StanzaHub   string // host:port (ipv4, ipv6, or resolvable hostname)
+
+	Decorators []string // prefetch config for these decorators
 }
 
 // Init initializes the SDK with ClientOptions. The returned error is

--- a/stanza/state.go
+++ b/stanza/state.go
@@ -23,6 +23,8 @@ import (
 )
 
 const (
+	MIN_POLLING_TIME = 15 * time.Second
+
 	filePerms = 0660
 )
 
@@ -75,7 +77,6 @@ func newState(ctx context.Context, co ClientOptions) func() {
 	initOnce.Do(func() {
 		// prepare for global state mutation
 		gsLock.Lock()
-		defer gsLock.Unlock()
 
 		// initialize new global state
 		gs = state{
@@ -112,8 +113,24 @@ func newState(ctx context.Context, co ClientOptions) func() {
 			}
 		}
 
+		if len(gs.clientOpt.Decorators) > 0 {
+			for _, decorator := range gs.clientOpt.Decorators {
+				gs.decoratorConfig[decorator] = &hubv1.DecoratorConfig{}
+				gs.decoratorConfigTime[decorator] = time.Time{}
+				gs.decoratorConfigVersion[decorator] = ""
+			}
+		}
+
+		// end global state mutation
+		gsLock.Unlock()
+
 		// connect to stanza-hub
-		go connectHub(ctx)
+		if gs.hubConn == nil {
+			hubConnect(ctx)
+		}
+
+		// start background polling for updates
+		go hubPoller(ctx, MIN_POLLING_TIME)
 	})
 	return func() {
 		stop()
@@ -124,9 +141,50 @@ func newState(ctx context.Context, co ClientOptions) func() {
 	}
 }
 
-func connectHub(ctx context.Context) {
-	const MIN_POLLING_TIME = 5 * time.Second
+func hubConnect(ctx context.Context) (func(), func()) {
+	tlsConfig := &tls.Config{}
+	if caPath := os.Getenv("STANZA_AWS_ROOT_CA"); caPath != "" {
+		tlsConfig.RootCAs = ca.AWSRootCAs(caPath)
+	}
+	creds := credentials.NewTLS(tlsConfig)
+	if os.Getenv("STANZA_HUB_NO_TLS") != "" { // disable TLS for local Hub development
+		creds = insecure.NewCredentials()
+	}
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
+		// grpc.WithUserAgent(), // todo: SDK spec
+		// todo: add keepalives, backoff config, etc
+	}
+	hubConn, err := grpc.Dial(gs.clientOpt.StanzaHub, opts...)
+	if err != nil {
+		logging.Error(err,
+			"msg", "failed to connect to stanza hub",
+			"url", gs.clientOpt.StanzaHub)
+	} else {
+		gsLock.Lock()
+		gs.hubConn = hubConn
+		gs.hubAuthClient = hubv1.NewAuthServiceClient(hubConn)
+		gs.hubConfigClient = hubv1.NewConfigServiceClient(hubConn)
+		gs.hubQuotaClient = hubv1.NewQuotaServiceClient(hubConn)
+		gsLock.Unlock()
 
+		// attempt to establish hub connection (doesn't block)
+		gs.hubConn.Connect()
+
+		// block, waiting for up to 10 seconds for hub connection
+		ctxWait, ctxWaitCancel := context.WithTimeout(ctx, 10*time.Second)
+		defer ctxWaitCancel()
+		gs.hubConn.WaitForStateChange(ctxWait, connectivity.Connecting)
+		if gs.hubConn.GetState() == connectivity.Ready {
+			logging.Debug("connected to stanza hub", "url", gs.clientOpt.StanzaHub)
+			fetchConfigs(ctx, true)
+			return OtelStartup(ctx), SentinelStartup(ctx)
+		}
+	}
+	return func() {}, func() {}
+}
+
+func hubPoller(ctx context.Context, pollInterval time.Duration) {
 	connectAttempt := 0
 	otelShutdown := func() {}
 	sentinelShutdown := func() {}
@@ -136,63 +194,55 @@ func connectHub(ctx context.Context) {
 			otelShutdown()
 			sentinelShutdown()
 			return
-		case <-time.After(MIN_POLLING_TIME):
+		case <-time.After(pollInterval):
 			if gs.hubConn != nil {
 				if gs.hubConn.GetState() == connectivity.Ready {
 					connectAttempt = 0
-					otelShutdown = OtelStartup(ctx)
-					sentinelShutdown = SentinelStartup(ctx)
-					GetServiceConfig(ctx)
-					GetDecoratorConfigs(ctx)
-					if gs.httpOutboundHandler != nil {
-						gs.httpOutboundHandler.SetCustomerId(gs.svcConfig.GetCustomerId())
-						gs.httpOutboundHandler.SetQuotaServiceClient(gs.hubQuotaClient)
-						for d := range gs.decoratorConfig {
-							gs.httpOutboundHandler.SetDecoratorConfig(d, gs.decoratorConfig[d])
-						}
-					}
-					if gs.httpInboundHandler != nil {
-						gs.httpInboundHandler.SetCustomerId(gs.svcConfig.GetCustomerId())
-						gs.httpInboundHandler.SetQuotaServiceClient(gs.hubQuotaClient)
-						for d := range gs.decoratorConfig {
-							gs.httpInboundHandler.SetDecoratorConfig(d, gs.decoratorConfig[d])
-						}
-					}
+					fetchConfigs(ctx, false)
 				} else {
-					connectAttempt += 1
-					logging.Debug(
-						"attempting to connect",
-						"uri", gs.clientOpt.StanzaHub,
-						"attempt", connectAttempt,
-					)
-					gs.hubConn.Connect()
+					// 120 attempts * 15 seconds == 1800 seconds == 30 minutes
+					if connectAttempt > 120 {
+						// if we have been stuck trying to connect for a "long time",
+						// discard the virtual connection handle and let hubConnect()
+						// create a new one on the next loop
+						connectAttempt = 0
+						gs.hubConn = nil
+					} else {
+						connectAttempt += 1
+						logging.Debug(
+							"attempting to connect",
+							"uri", gs.clientOpt.StanzaHub,
+							"attempt", connectAttempt,
+						)
+						gs.hubConn.Connect()
+					}
 				}
 			} else {
-				tlsConfig := &tls.Config{}
-				if caPath := os.Getenv("STANZA_AWS_ROOT_CA"); caPath != "" {
-					tlsConfig.RootCAs = ca.AWSRootCAs(caPath)
-				}
-				creds := credentials.NewTLS(tlsConfig)
-				if os.Getenv("STANZA_HUB_NO_TLS") != "" { // disable TLS for local Hub development
-					creds = insecure.NewCredentials()
-				}
-				opts := []grpc.DialOption{
-					grpc.WithTransportCredentials(creds),
-					// grpc.WithUserAgent(), // todo: SDK spec
-					// todo: add keepalives, backoff config, etc
-				}
-				hubConn, err := grpc.Dial(gs.clientOpt.StanzaHub, opts...)
-				if err != nil {
-					logging.Error(err,
-						"msg", "failed to connect to stanza hub",
-						"url", gs.clientOpt.StanzaHub)
-				} else {
-					gs.hubConn = hubConn
-					gs.hubAuthClient = hubv1.NewAuthServiceClient(hubConn)
-					gs.hubConfigClient = hubv1.NewConfigServiceClient(hubConn)
-					gs.hubQuotaClient = hubv1.NewQuotaServiceClient(hubConn)
-				}
+				otelShutdown, sentinelShutdown = hubConnect(ctx)
 			}
 		}
+	}
+}
+
+func fetchConfigs(ctx context.Context, skipPoll bool) {
+	GetServiceConfig(ctx, skipPoll)
+	GetDecoratorConfigs(ctx, skipPoll)
+	if gs.httpOutboundHandler != nil {
+		gsLock.Lock()
+		gs.httpOutboundHandler.SetCustomerId(gs.svcConfig.GetCustomerId())
+		gs.httpOutboundHandler.SetQuotaServiceClient(gs.hubQuotaClient)
+		for d := range gs.decoratorConfig {
+			gs.httpOutboundHandler.SetDecoratorConfig(d, gs.decoratorConfig[d])
+		}
+		gsLock.Unlock()
+	}
+	if gs.httpInboundHandler != nil {
+		gsLock.Lock()
+		gs.httpInboundHandler.SetCustomerId(gs.svcConfig.GetCustomerId())
+		gs.httpInboundHandler.SetQuotaServiceClient(gs.hubQuotaClient)
+		for d := range gs.decoratorConfig {
+			gs.httpInboundHandler.SetDecoratorConfig(d, gs.decoratorConfig[d])
+		}
+		gsLock.Unlock()
 	}
 }


### PR DESCRIPTION
- SDK spec compliant init sequence (block on *first* `GetServiceConfig` attempt and retry every 15 seconds until we get an initial config)
- New optional init parameter to allow prefetching of Decorator config

`fiber-example` startup with debug logging showing successfully connecting to hub on the first try (fiber serving starts after all remote configs have been fetched):
```
{"level":"debug","ts":1691783029.5892138,"msg":"connected to stanza hub","url":"hub.dev.getstanza.dev:9020"}
{"level":"debug","ts":1691783029.6541026,"msg":"accepted service config","version":"1055779496"}
{"level":"debug","ts":1691783029.7111232,"msg":"accepted decorator config","decorator":"StressTest","version":"1803783363"}
{"level":"debug","ts":1691783029.935273,"msg":"obtained bearer token"}
{"level":"debug","ts":1691783029.9354875,"msg":"initialized opentelemetry exporter"}
{"level":"info","ts":1691783029.9355357,"msg":"[Config] Print effective global config","globalConfig":{"Version":"v1","Sentinel":{"App":{"Name":"fiber-example","Type":0},"Exporter":{"Metric":{"HttpAddr":"","HttpPath":""}},"Log":{"Logger":{},"Dir":"/home/vscode/logs/csp","UsePid":false,"Metric":{"SingleFileMaxSize":52428800,"MaxFileCount":8,"FlushIntervalSec":0}},"Stat":{"GlobalStatisticSampleCountTotal":20,"GlobalStatisticIntervalMsTotal":10000,"MetricStatisticSampleCount":2,"MetricStatisticIntervalMs":1000,"System":{"CollectIntervalMs":1000,"CollectLoadIntervalMs":1000,"CollectCpuIntervalMs":1000,"CollectMemoryIntervalMs":150}},"UseCacheTime":false}}}
{"level":"info","ts":1691783029.9370546,"msg":"[CircuitBreaker] Load rules is the same with current rules, so ignore load operation."}
{"level":"info","ts":1691783029.9372482,"msg":"[Flow] Load rules is the same with current rules, so ignore load operation."}
{"level":"info","ts":1691783029.937365,"msg":"[Isolation] Load rules is the same with current rules, so ignore load operation."}
{"level":"info","ts":1691783029.9374833,"msg":"[System] Load rules is the same with current rules, so ignore load operation."}
{"level":"debug","ts":1691783029.937608,"msg":"initialized sentinel rules watcher"}
{"level":"debug","ts":1691783030.0019915,"msg":"accepted decorator config","decorator":"RootDecorator","version":"0"}

 ┌───────────────────────────────────────────────────┐ 
 │                   Fiber v2.48.0                   │ 
 │               http://127.0.0.1:3000               │ 
 │       (bound on host 0.0.0.0 and port 3000)       │ 
 │                                                   │ 
 │ Handlers ............. 8  Processes ........... 1 │ 
 │ Prefork ....... Disabled  PID .............. 5281 │ 
 └───────────────────────────────────────────────────┘ 
```

`fiber-example` startup with debug logging showing it doesn't block serving on hub connection failure (and will continue to attempt to connect to Hub per SDK spec):
```
{"level":"error","ts":1691783724.8016682,"msg":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp: lookup hu.dev.getstanza.dev on 192.168.65.7:53: no such host\""}

 ┌───────────────────────────────────────────────────┐ 
 │                   Fiber v2.48.0                   │ 
 │               http://127.0.0.1:3000               │ 
 │       (bound on host 0.0.0.0 and port 3000)       │ 
 │                                                   │ 
 │ Handlers ............. 8  Processes ........... 1 │ 
 │ Prefork ....... Disabled  PID .............. 7758 │ 
 └───────────────────────────────────────────────────┘ 

{"level":"debug","ts":1691783739.8062065,"msg":"attempting to connect","uri":"hu.dev.getstanza.dev:9020","attempt":1}
{"level":"debug","ts":1691783754.8077037,"msg":"attempting to connect","uri":"hu.dev.getstanza.dev:9020","attempt":2}
```