### PR TITLE
Report CheckQuota/ValidateTokens reasons

### DIFF
--- a/global/config.go
+++ b/global/config.go
@@ -48,6 +48,21 @@ func OtelStartup(ctx context.Context) func() {
 
 			gs.otelInit = true
 			logging.Debug("initialized opentelemetry exporter")
+
+			if gs.svcConfig != nil {
+				if err := otel.InitMetricProvider(ctx, gs.svcConfig.GetMetricConfig(), gs.bearerToken, UserAgent()); err != nil {
+					logging.Error(err)
+				} else {
+					logging.Debug("accepted opentelemetry metric config",
+						"version", gs.svcConfigVersion)
+				}
+				if err := otel.InitTraceProvider(ctx, gs.svcConfig.GetTraceConfig(), gs.bearerToken, UserAgent()); err != nil {
+					logging.Error(err)
+				} else {
+					logging.Debug("accepted opentelemetry trace config",
+						"version", gs.svcConfigVersion)
+				}
+			}
 		}
 	}
 	return otelDone

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -73,6 +73,10 @@ func (h *Handler) ReasonQuota() attribute.KeyValue {
 	return reasonKey.String("quota")
 }
 
+func (h *Handler) ReasonToken() attribute.KeyValue {
+	return reasonKey.String("token")
+}
+
 // Global Helper Functions //
 func (h *Handler) APIKey() string {
 	return global.GetServiceKey()


### PR DESCRIPTION
- Report `CheckQuota` and `ValidateTokens` reasons
- Fix bug where OTEL metrics and traces would not be sent until after a new ServiceConfig was recieved (`GetServiceConfig` happens before `OtelStartup` now)