### PR TITLE
Fix otel/sentinel refresh bug

### DIFF
--- a/global/hub.go
+++ b/global/hub.go
@@ -84,6 +84,8 @@ func hubPoller(ctx context.Context, pollInterval time.Duration) {
 					}
 					GetServiceConfig(ctx, false)
 					GetGuardConfigs(ctx, false)
+					otelShutdown = OtelStartup(ctx)
+					sentinelShutdown = SentinelStartup(ctx)
 				} else {
 					// 120 attempts * 15 seconds == 1800 seconds == 30 minutes
 					if connectAttempt > 120 {


### PR DESCRIPTION
- Call OtelStartup and SentinelStartup functions during hubPoller `MIN_POLLING_TIME` loop

Q: Is it safe to do so?
A: Yes. OtelStartup calls GetNewBearerToken which is itself gated by `BEARER_TOKEN_REFRESH_INTERVAL`: https://github.com/StanzaSystems/sdk-go/blob/c76140095cab4e7d03fa1f695e53a752545aac92/global/config.go#L72

And SentinelStartup simply returns if sentinelInit has completed successfully.

Also this is how it used to work and this is a bug/regression from the global state and startup sequence refactoring work.