### PR TITLE
Generic HTTP server middleware and many bugfixes

### DIFF
--- a/adapters/fiberstanza/example/go.mod
+++ b/adapters/fiberstanza/example/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/adapters/fiberstanza/example/go.sum
+++ b/adapters/fiberstanza/example/go.sum
@@ -62,6 +62,8 @@ github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4s
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
+github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/adapters/fiberstanza/go.mod
+++ b/adapters/fiberstanza/go.mod
@@ -9,8 +9,6 @@ require (
 	github.com/gofiber/fiber/v2 v2.49.1
 	github.com/valyala/fasthttp v1.49.0
 	go.opentelemetry.io/otel v1.17.0
-	go.opentelemetry.io/otel/metric v1.17.0
-	go.opentelemetry.io/otel/trace v1.17.0
 )
 
 require (
@@ -20,6 +18,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -56,8 +55,10 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.17.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.17.0 // indirect
+	go.opentelemetry.io/otel/metric v1.17.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.17.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v0.40.0 // indirect
+	go.opentelemetry.io/otel/trace v1.17.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.25.0 // indirect

--- a/adapters/fiberstanza/go.sum
+++ b/adapters/fiberstanza/go.sum
@@ -62,6 +62,8 @@ github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4s
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
+github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/adapters/grpc/example/zap.go
+++ b/adapters/grpc/example/zap.go
@@ -68,7 +68,7 @@ func zapInterceptor(l *zap.Logger) logging.Logger {
 	})
 }
 
-func logSkip(_ context.Context, c interceptors.CallMeta) bool {
+func serviceMatcher(_ context.Context, c interceptors.CallMeta) bool {
 	return c.Service == "quote.v1.QuoteService"
 }
 

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/felixge/httpsnoop v1.0.3
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4s
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
+github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/StanzaSystems/sdk-go/otel"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -140,4 +141,12 @@ func (h *Handler) SentinelEnabled() bool {
 
 func (h *Handler) QuotaServiceClient() hubv1.QuotaServiceClient {
 	return global.QuotaServiceClient()
+}
+
+func (h *Handler) FailOpen(ctx context.Context) {
+	if h.meter != nil {
+		h.meter.AllowedSuccessCount.Add(ctx, 1,
+			[]metric.AddOption{metric.WithAttributes(append(h.attr,
+				h.ReasonFailOpen())...)}...)
+	}
 }

--- a/handlers/httphandler/server.go
+++ b/handlers/httphandler/server.go
@@ -1,20 +1,94 @@
 package httphandler
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+
 	"github.com/StanzaSystems/sdk-go/handlers"
+	"github.com/StanzaSystems/sdk-go/keys"
+
+	"github.com/felixge/httpsnoop"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	"go.opentelemetry.io/otel/semconv/v1.20.0/httpconv"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type InboundHandler struct {
 	*handlers.InboundHandler
+	guardName     string
+	featureName   *string  // overrides request baggage
+	priorityBoost *int32   // overrides request baggage
+	defaultWeight *float32 // overrides request baggage
 }
 
 // NewInboundHandler returns a new InboundHandler
-func NewInboundHandler() (*InboundHandler, error) {
+func NewInboundHandler(gn string, fn *string, pb *int32, dw *float32) (*InboundHandler, error) {
 	h, err := handlers.NewInboundHandler()
 	if err != nil {
 		return nil, err
 	}
-	return &InboundHandler{h}, nil
+	return &InboundHandler{h, gn, fn, pb, dw}, nil
 }
 
-// TODO: Add generic HTTP server middleware
+// Guard implements HTTP handler (middleware) for adding a Stanza Guard to an HTTP Server
+func (h *InboundHandler) Guard(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		ctx, span, tokens := h.Start(r)
+		defer span.End()
+
+		guard := h.NewGuard(ctx, span, h.guardName, tokens)
+		if guard.Blocked() {
+			span.SetStatus(codes.Error, guard.BlockMessage())
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(guard.BlockMessage()))
+			return
+		}
+
+		m := httpsnoop.CaptureMetrics(next, w, r.WithContext(ctx))
+		span.SetAttributes(semconv.HTTPStatusCode(m.Code))
+		span.SetStatus(h.HTTPServerStatus(m.Code))
+		if m.Code != http.StatusOK {
+			guard.End(guard.Failure)
+		} else {
+			guard.End(guard.Success)
+		}
+	}
+	return http.HandlerFunc(fn)
+}
+
+func (h *InboundHandler) Start(r *http.Request) (context.Context, trace.Span, []string) {
+	ctx := h.Propagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+	if h.featureName != nil {
+		ctx = context.WithValue(ctx, keys.StanzaFeatureNameKey, *h.featureName)
+	}
+	if h.priorityBoost != nil {
+		ctx = context.WithValue(ctx, keys.StanzaPriorityBoostKey, *h.priorityBoost)
+	}
+	if h.defaultWeight != nil {
+		ctx = context.WithValue(ctx, keys.StanzaDefaultWeightKey, *h.defaultWeight)
+	}
+
+	ctx, span := h.Tracer().Start(
+		ctx,
+		r.URL.Path,
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(httpconv.ServerRequest("", r)...),
+	)
+	return ctx, span, r.Header.Values("x-stanza-token")
+}
+
+// HTTPServerStatus returns a span status code and message for an HTTP status code
+// value returned by a server. Status codes in the 400-499 range are not
+// returned as errors.
+func (h *InboundHandler) HTTPServerStatus(code int) (codes.Code, string) {
+	if code < 100 || code >= 600 {
+		return codes.Error, fmt.Sprintf("Invalid HTTP status code %d", code)
+	}
+	if code >= 500 {
+		return codes.Error, ""
+	}
+	return codes.Unset, ""
+}

--- a/stanza/handlers.go
+++ b/stanza/handlers.go
@@ -11,8 +11,8 @@ func NewHttpOutboundHandler() (*httphandler.OutboundHandler, error) {
 }
 
 // HTTP Server
-func NewHttpInboundHandler() (*httphandler.InboundHandler, error) {
-	return httphandler.NewInboundHandler()
+func NewHttpInboundHandler(gn string, fn *string, pb *int32, dw *float32) (*httphandler.InboundHandler, error) {
+	return httphandler.NewInboundHandler(gn, fn, pb, dw)
 }
 
 // gRPC Client
@@ -21,6 +21,6 @@ func NewGrpcOutboundHandler() (*grpchandler.OutboundHandler, error) {
 }
 
 // gRPC Server
-func NewGrpcInboundHandler() (*grpchandler.InboundHandler, error) {
-	return grpchandler.NewInboundHandler()
+func NewGrpcInboundHandler(gn string, fn *string, pb *int32, dw *float32) (*grpchandler.InboundHandler, error) {
+	return grpchandler.NewInboundHandler(gn, fn, pb, dw)
 }


### PR DESCRIPTION
- Generic HTTP server middleware (used by stanzahttp example)
- Refactored fiberstanza (to use the same generic HTTP server functions where possible)
- Fixed overriding Feature, Priority Boost, and setting Default Weight everywhere