### PR TITLE
Add ContextWithHeaders helper

### DIFF
--- a/adapters/stanzahttp/example/main.go
+++ b/adapters/stanzahttp/example/main.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 
 	"github.com/StanzaSystems/sdk-go/stanza"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -88,7 +89,7 @@ func main() {
 	// Use ZenQuotes to get a random quote
 	r.HandleFunc("/quote", func(w http.ResponseWriter, r *http.Request) {
 		// Name the Stanza Guard which protects this workflow
-		stz := stanza.Guard(ctx, "ZenQuotes")
+		stz := stanza.Guard(stanza.ContextWithHeaders(r), "ZenQuotes")
 
 		// Check for and log any returned error messages
 		if stz.Error() != nil {
@@ -122,7 +123,8 @@ func main() {
 
 	go http.ListenAndServe(
 		fmt.Sprintf(":%d", port),
-		stanza.GuardHandler(r, "RootGuard"), // Add a Stanza Guard as HTTP middleware for ALL requests!
+		// stanza.GuardHandler(r, "RootGuard"), // Add a Stanza Guard as HTTP middleware for ALL requests!
+		r,
 	)
 
 	// GRACEFUL SHUTDOWN

--- a/stanza/helpers.go
+++ b/stanza/helpers.go
@@ -10,7 +10,9 @@ import (
 	"github.com/StanzaSystems/sdk-go/handlers/grpchandler"
 	"github.com/StanzaSystems/sdk-go/handlers/httphandler"
 	"github.com/StanzaSystems/sdk-go/logging"
+	"github.com/StanzaSystems/sdk-go/otel"
 
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 )
@@ -93,6 +95,10 @@ func Guard(ctx context.Context, guardName string, opts ...GuardOpt) *handlers.Gu
 	ctx, span := h.Tracer().Start(ctx, guardName, traceOpts...)
 	defer span.End()
 	return h.Guard(ctx, span, []string{})
+}
+
+func ContextWithHeaders(r *http.Request) context.Context {
+	return otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
 }
 
 func withOpts(gn string, opts ...GuardOpt) (string, *string, *int32, *float32) {


### PR DESCRIPTION
Use the `http.Request` context w/ baggage header propagation via context in the `stanzahttp` example app.

This makes it so this: `$ curl -H 'baggage:stz-feat=test,stz-boost=1' http://localhost:3000/quote`

does this:
```
{"level":"debug","ts":1694639877.8904128,"msg":"Stanza allowed","guard":"ZenQuotes","feature":"test","priority_boost":"1","reason":"quota"}
```

(OTEL baggage is inspected and used by the stanzahttp example app)