### PR TITLE
Bugfix for Report Only mode statistics

### DIFF
--- a/handlers/guard.go
+++ b/handlers/guard.go
@@ -49,6 +49,11 @@ type Guard struct {
 }
 
 func (g *Guard) Allowed() bool {
+	// Report Only mode always allows
+	if g.config != nil && g.config.ReportOnly {
+		return true
+	}
+
 	// Default to "allowed", unless one of our checks *explicitly* blocks
 	if g.localStatus != hubv1.Local_LOCAL_BLOCKED &&
 		g.quotaStatus != hubv1.Quota_QUOTA_BLOCKED &&
@@ -59,6 +64,11 @@ func (g *Guard) Allowed() bool {
 }
 
 func (g *Guard) Blocked() bool {
+	// Report Only mode always allows
+	if g.config != nil && g.config.ReportOnly {
+		return false
+	}
+
 	// Default to "allowed", unless one of our checks *explicitly* blocks
 	if g.localStatus == hubv1.Local_LOCAL_BLOCKED ||
 		g.quotaStatus == hubv1.Quota_QUOTA_BLOCKED ||

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -63,10 +63,6 @@ func (h *Handler) Guard(ctx context.Context, span trace.Span, tokens []string) *
 	// Local (Sentinel) check
 	err = g.checkLocal(ctx, h.guardName, h.SentinelEnabled())
 	if err != nil || g.localStatus == hubv1.Local_LOCAL_BLOCKED {
-		if g.config.ReportOnly {
-			g.localStatus = hubv1.Local_LOCAL_ALLOWED
-			g.allowed(ctx)
-		}
 		return g
 	}
 


### PR DESCRIPTION
Bugfix: Per SDK spec, we shouldn't alter the allowed/blocked counters (instead we handle ReportOnly in the `Allowed()` and `Blocked()` functions which are checked as the final action to decide if the request should be allowed or blocked.