### PR TITLE
Conform to "Hierarchical Guards and Tags" section of the SDK spec

### DIFF
--- a/adapters/fiberstanza/example/server.go
+++ b/adapters/fiberstanza/example/server.go
@@ -109,9 +109,11 @@ func main() {
 
 	// Use ZenQuotes to get a random quote
 	app.Get("/quote", func(c *fiber.Ctx) error {
+		opt := fiberstanza.Opt{Tags: make(map[string]string)}
+		opt.Tags["tier"] = "MEGA"
 
 		// Outbound request with ZenQuotes Guard
-		resp, err := fiberstanza.HttpGet(c, "ZenQuotes", "https://zenquotes.io/api/random")
+		resp, err := fiberstanza.HttpGet(c, "ZenQuotes", "https://zenquotes.io/api/random", opt)
 		if err != nil {
 			logger.Error("ZenQuotes", zap.Error(err))
 		}

--- a/adapters/fiberstanza/fiberstanza.go
+++ b/adapters/fiberstanza/fiberstanza.go
@@ -37,6 +37,7 @@ type Opt struct {
 	Feature       string
 	PriorityBoost int32
 	DefaultWeight float32
+	Tags          map[string]string
 }
 
 // New creates a new fiberstanza middleware fiber.Handler
@@ -147,6 +148,9 @@ func withOpts(opts ...Opt) stanza.GuardOpt {
 		}
 		if opts[0].DefaultWeight != 0 {
 			guardOpt.DefaultWeight = &opts[0].DefaultWeight
+		}
+		if len(opts[0].Tags) > 0 {
+			guardOpt.Tags = &opts[0].Tags
 		}
 	}
 	return guardOpt

--- a/handlers/client.go
+++ b/handlers/client.go
@@ -4,7 +4,7 @@ type OutboundHandler struct {
 	*Handler
 }
 
-func NewOutboundHandler(gn string, fn *string, pb *int32, dw *float32) (*OutboundHandler, error) {
-	h, err := NewHandler(gn, fn, pb, dw)
+func NewOutboundHandler(gn string, fn *string, pb *int32, dw *float32, kv *map[string]string) (*OutboundHandler, error) {
+	h, err := NewHandler(gn, fn, pb, dw, kv)
 	return &OutboundHandler{h}, err
 }

--- a/handlers/grpchandler/client.go
+++ b/handlers/grpchandler/client.go
@@ -23,8 +23,8 @@ type OutboundHandler struct {
 }
 
 // NewOutboundHandler returns a new OutboundHandler
-func NewOutboundHandler(gn string, fn *string, pb *int32, dw *float32) (*OutboundHandler, error) {
-	h, err := handlers.NewOutboundHandler(gn, fn, pb, dw)
+func NewOutboundHandler(gn string, fn *string, pb *int32, dw *float32, kv *map[string]string) (*OutboundHandler, error) {
+	h, err := handlers.NewOutboundHandler(gn, fn, pb, dw, kv)
 	if err != nil {
 		return nil, err
 	}

--- a/handlers/grpchandler/server.go
+++ b/handlers/grpchandler/server.go
@@ -20,8 +20,8 @@ type InboundHandler struct {
 }
 
 // NewInboundHandler returns a new InboundHandler
-func NewInboundHandler(gn string, fn *string, pb *int32, dw *float32) (*InboundHandler, error) {
-	h, err := handlers.NewInboundHandler(gn, fn, pb, dw)
+func NewInboundHandler(gn string, fn *string, pb *int32, dw *float32, kv *map[string]string) (*InboundHandler, error) {
+	h, err := handlers.NewInboundHandler(gn, fn, pb, dw, kv)
 	if err != nil {
 		return nil, err
 	}

--- a/handlers/httphandler/client.go
+++ b/handlers/httphandler/client.go
@@ -22,8 +22,8 @@ type OutboundHandler struct {
 }
 
 // NewOutboundHandler returns a new OutboundHandler
-func NewOutboundHandler(gn string, fn *string, pb *int32, dw *float32) (*OutboundHandler, error) {
-	h, err := handlers.NewOutboundHandler(gn, fn, pb, dw)
+func NewOutboundHandler(gn string, fn *string, pb *int32, dw *float32, kv *map[string]string) (*OutboundHandler, error) {
+	h, err := handlers.NewOutboundHandler(gn, fn, pb, dw, kv)
 	if err != nil {
 		return nil, err
 	}

--- a/handlers/httphandler/server.go
+++ b/handlers/httphandler/server.go
@@ -20,8 +20,8 @@ type InboundHandler struct {
 }
 
 // NewInboundHandler returns a new InboundHandler
-func NewInboundHandler(gn string, fn *string, pb *int32, dw *float32) (*InboundHandler, error) {
-	h, err := handlers.NewInboundHandler(gn, fn, pb, dw)
+func NewInboundHandler(gn string, fn *string, pb *int32, dw *float32, kv *map[string]string) (*InboundHandler, error) {
+	h, err := handlers.NewInboundHandler(gn, fn, pb, dw, kv)
 	if err != nil {
 		return nil, err
 	}

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -5,7 +5,7 @@ type InboundHandler struct {
 }
 
 // NewInboundHandler returns a new InboundHandler
-func NewInboundHandler(gn string, fn *string, pb *int32, dw *float32) (*InboundHandler, error) {
-	h, err := NewHandler(gn, fn, pb, dw)
+func NewInboundHandler(gn string, fn *string, pb *int32, dw *float32, kv *map[string]string) (*InboundHandler, error) {
+	h, err := NewHandler(gn, fn, pb, dw, kv)
 	return &InboundHandler{h}, err
 }

--- a/stanza/handlers.go
+++ b/stanza/handlers.go
@@ -6,21 +6,21 @@ import (
 )
 
 // HTTP Client
-func NewHttpOutboundHandler(gn string, fn *string, pb *int32, dw *float32) (*httphandler.OutboundHandler, error) {
-	return httphandler.NewOutboundHandler(gn, fn, pb, dw)
+func NewHttpOutboundHandler(gn string, fn *string, pb *int32, dw *float32, kv *map[string]string) (*httphandler.OutboundHandler, error) {
+	return httphandler.NewOutboundHandler(gn, fn, pb, dw, kv)
 }
 
 // HTTP Server
-func NewHttpInboundHandler(gn string, fn *string, pb *int32, dw *float32) (*httphandler.InboundHandler, error) {
-	return httphandler.NewInboundHandler(gn, fn, pb, dw)
+func NewHttpInboundHandler(gn string, fn *string, pb *int32, dw *float32, kv *map[string]string) (*httphandler.InboundHandler, error) {
+	return httphandler.NewInboundHandler(gn, fn, pb, dw, kv)
 }
 
 // gRPC Client
-func NewGrpcOutboundHandler(gn string, fn *string, pb *int32, dw *float32) (*grpchandler.OutboundHandler, error) {
-	return grpchandler.NewOutboundHandler(gn, fn, pb, dw)
+func NewGrpcOutboundHandler(gn string, fn *string, pb *int32, dw *float32, kv *map[string]string) (*grpchandler.OutboundHandler, error) {
+	return grpchandler.NewOutboundHandler(gn, fn, pb, dw, kv)
 }
 
 // gRPC Server
-func NewGrpcInboundHandler(gn string, fn *string, pb *int32, dw *float32) (*grpchandler.InboundHandler, error) {
-	return grpchandler.NewInboundHandler(gn, fn, pb, dw)
+func NewGrpcInboundHandler(gn string, fn *string, pb *int32, dw *float32, kv *map[string]string) (*grpchandler.InboundHandler, error) {
+	return grpchandler.NewInboundHandler(gn, fn, pb, dw, kv)
 }

--- a/stanza/helpers.go
+++ b/stanza/helpers.go
@@ -20,6 +20,7 @@ type GuardOpt struct {
 	Feature       *string
 	PriorityBoost *int32
 	DefaultWeight *float32
+	Tags          *map[string]string
 }
 
 // HttpServer is a helper function to Guard inbound HTTP requests
@@ -134,10 +135,11 @@ func ContextWithHeaders(r *http.Request) context.Context {
 	return otel.ContextWithHeaders(r)
 }
 
-func withOpts(gn string, opts ...GuardOpt) (string, *string, *int32, *float32) {
+func withOpts(gn string, opts ...GuardOpt) (string, *string, *int32, *float32, *map[string]string) {
 	var fn *string
 	var pb *int32
 	var dw *float32
+	var kv *map[string]string
 	if len(opts) == 1 {
 		if opts[0].Feature != nil {
 			fn = opts[0].Feature
@@ -148,6 +150,9 @@ func withOpts(gn string, opts ...GuardOpt) (string, *string, *int32, *float32) {
 		if opts[0].DefaultWeight != nil {
 			dw = opts[0].DefaultWeight
 		}
+		if opts[0].Tags != nil {
+			kv = opts[0].Tags
+		}
 	}
-	return gn, fn, pb, dw
+	return gn, fn, pb, dw, kv
 }


### PR DESCRIPTION

Showing off our fiberstanza-example app:
1. At first ignores the invalid tag
2. Gets a Guard config update (which adds the quota_tag)
3. Sends the tag key and value as part of the GetTokenLeaseRequest (shown via a debug println)
```
{"level":"debug","ts":1707949032.8489513,"msg":"accepted guard config","guard":"ZenQuotes","version":"1803783363"}
{"level":"info","ts":1707949032.849081,"msg":"skipping unknown tag","tag":"tier","guard":"ZenQuotes"}
selector:{environment:"msg"  guard_name:"ZenQuotes"}  client_id:"39670027-6b8e-46a5-afe5-62960afd888f"
{"level":"debug","ts":1707949032.9008143,"msg":"Stanza allowed","guard":"ZenQuotes","config_state":"CONFIG_CACHED_OK","local_reason":"LOCAL_EVAL_DISABLED","token_reason":"TOKEN_EVAL_DISABLED","quota_reason":"QUOTA_GRANTED","mode":"MODE_NORMAL"}
{"level":"info","ts":1707949033.1595147,"msg":"Success","latency":"363.996792ms","status":200,"method":"GET","url":"/quote"}
{"level":"debug","ts":1707949089.8836188,"msg":"accepted guard config","guard":"ZenQuotes","version":"1345250766"}
selector:{environment:"msg"  guard_name:"ZenQuotes"  tags:{key:"tier"  value:"MEGA"}}  client_id:"39670027-6b8e-46a5-afe5-62960afd888f"
{"level":"debug","ts":1707949093.7676816,"msg":"Stanza allowed","guard":"ZenQuotes","config_state":"CONFIG_CACHED_OK","local_reason":"LOCAL_EVAL_DISABLED","token_reason":"TOKEN_EVAL_DISABLED","quota_reason":"QUOTA_GRANTED","mode":"MODE_NORMAL"}
{"level":"info","ts":1707949094.053903,"msg":"Success","latency":"344.61725ms","status":200,"method":"GET","url":"/quote"}
```